### PR TITLE
Native fonts settings

### DIFF
--- a/src/net/algem/Algem.java
+++ b/src/net/algem/Algem.java
@@ -94,6 +94,9 @@ public class Algem
 
     setLocale(props);
 
+    if (!isFeatureEnabled("native_fonts")) {
+      initUIFonts();
+    }
     /* -------------------------- */
     /* Initialisation driver JDBC */
     /* -------------------------- */
@@ -354,6 +357,21 @@ public class Algem
       baseArg = args[3];
     }
 
+
+    try {
+      appli = new Algem();
+      appli.init(confArg, hostArg, baseArg, userArg);
+    } catch (Exception ex) {
+      JOptionPane.showMessageDialog(null,
+              ex.getMessage(),
+              MessageUtil.getMessage("application.create.error"),
+              JOptionPane.ERROR_MESSAGE);
+      ex.printStackTrace();
+      System.exit(7);
+    }
+  }
+
+  private void initUIFonts() {
     Font fsans = new Font("Lucida Sans", Font.BOLD, 12);
     Font fserif = new Font(Font.SERIF, Font.BOLD + Font.ITALIC, 12);
 
@@ -369,18 +387,6 @@ public class Algem
     UIManager.put("CheckBoxMenuItem.font", fsans);
     UIManager.put("TitledBorder.font", fsans.deriveFont(Font.BOLD + Font.ITALIC));
     UIManager.put("RadioButton.font", fsans);
-
-    try {
-      appli = new Algem();
-      appli.init(confArg, hostArg, baseArg, userArg);
-    } catch (Exception ex) {
-      JOptionPane.showMessageDialog(null,
-              ex.getMessage(),
-              MessageUtil.getMessage("application.create.error"),
-              JOptionPane.ERROR_MESSAGE);
-      ex.printStackTrace();
-      System.exit(7);
-    }
   }
 }
 


### PR DESCRIPTION
Permet de garder, optionnellement, les polices natives par défaut.

Si la feature `native_fonts` est activée, la méthode `Algem.initUIFonts()` n'est pas appelée et les polices natives sont conservées.
