### PR TITLE
Mutualisation couleur vue planning / export

### DIFF
--- a/src/net/algem/planning/CourseSchedule.java
+++ b/src/net/algem/planning/CourseSchedule.java
@@ -72,7 +72,7 @@ public class CourseSchedule
 
   @Override
   public String getScheduleLabel() {
-    return ((Course) activity).getTitle();
+    return activity != null ? ((Course) activity).getTitle() : "";
   }
 
   @Override

--- a/src/net/algem/planning/ScheduleCanvas.java
+++ b/src/net/algem/planning/ScheduleCanvas.java
@@ -85,6 +85,8 @@ public abstract class ScheduleCanvas
   protected Image img;
   protected ColorPrefs colorPrefs = new ColorPrefs();
   protected Cacheable actionIO = DataCache.getDao(Model.Action);
+  protected ScheduleColorizer colorizer = new ScheduleColorizer(colorPrefs, (ActionIO) actionIO);
+
 
   public void removeActionListener(ActionListener l) {
     listener = AWTEventMulticaster.remove(listener, l);
@@ -94,127 +96,6 @@ public abstract class ScheduleCanvas
     listener = AWTEventMulticaster.add(listener, l);
   }
 
-  /**
-   * Gets the background color.
-   *
-   * @param p schedule
-   * @return a color
-   */
-  protected Color getScheduleColor(ScheduleObject p) {
-    Color ac = null;
-    if (p instanceof ScheduleRangeObject) {
-      ac = getActionColor(((ScheduleRangeObject)p).getAction().getId());
-    } else {
-      ac = getActionColor(p.getIdAction());
-    }
-    if (ac != null) {
-      return (p instanceof ScheduleRangeObject ? ColorPrefs.brighten(ac) : ac);
-    }
-    return getDefaultScheduleColor(p);
-  }
-  
-  public Color getDefaultScheduleColor(ScheduleObject p) {
-    if (p instanceof ScheduleRangeObject) {
-      return colorPrefs.getColor(ColorPlan.RANGE);
-    }
-    switch (p.getType()) {
-      case Schedule.COURSE:
-        Room s = ((CourseSchedule) p).getRoom();
-        Course cc = ((CourseSchedule) p).getCourse();
-        if (s.isCatchingUp()) {
-          return colorPrefs.getColor(ColorPlan.CATCHING_UP);
-        } else {
-          if (cc != null && !cc.isCollective()) {
-            return colorPrefs.getColor(ColorPlan.COURSE_INDIVIDUAL);
-          } else {
-            if (cc != null && cc.isInstCode()) {
-              return colorPrefs.getColor(ColorPlan.INSTRUMENT_CO);
-            } else {
-              return colorPrefs.getColor(ColorPlan.COURSE_CO);
-            }
-          }
-        }
-      case Schedule.ACTION:
-        return colorPrefs.getColor(ColorPlan.ACTION);
-      case Schedule.MEMBER:
-        return  colorPrefs.getColor(ColorPlan.MEMBER_REHEARSAL);
-      case Schedule.GROUP:
-        return  colorPrefs.getColor(ColorPlan.GROUP_REHEARSAL);
-      case Schedule.WORKSHOP:
-        return  colorPrefs.getColor(ColorPlan.WORKSHOP);
-      case Schedule.TRAINING:
-        return  colorPrefs.getColor(ColorPlan.TRAINING);
-      case Schedule.STUDIO:
-      case Schedule.TECH:
-        return  colorPrefs.getColor(ColorPlan.STUDIO);
-      case Schedule.ADMINISTRATIVE:
-        return colorPrefs.getColor(ColorPlan.ADMINISTRATIVE);
-      default:
-        return Color.WHITE;
-    } // end switch couleurs
-  }
-  
-  private Color getActionColor(int action) {
-    return ((ActionIO) actionIO).getColor(action);
-  }
-
-  /**
-   * Gets the text color for headers.
-   *
-   * @param p schedule
-   * @return a color
-   */
-  protected Color getTextColor(ScheduleObject p) {
-    Color ac = getActionColor(p.getIdAction());
-    if (ac != null) {
-      return ColorPrefs.getForeground(ac);
-    }
-    switch (p.getType()) {
-      case Schedule.COURSE:
-        Room r = p.getRoom();
-        if (r.isCatchingUp()) {
-          return colorPrefs.getColor(ColorPlan.CATCHING_UP_LABEL);
-        } else if (((CourseSchedule) p).getCourse().isCollective()) {
-          return colorPrefs.getColor(ColorPlan.COURSE_CO_LABEL);
-        } else {
-          return colorPrefs.getColor(ColorPlan.COURSE_INDIVIDUAL_LABEL);
-        }
-      case Schedule.WORKSHOP:
-        return colorPrefs.getColor(ColorPlan.WORKSHOP_LABEL);
-      case Schedule.TRAINING:
-        return colorPrefs.getColor(ColorPlan.TRAINING_LABEL);
-      case Schedule.GROUP:
-        return colorPrefs.getColor(ColorPlan.GROUP_LABEL);
-      case Schedule.MEMBER:
-        return colorPrefs.getColor(ColorPlan.MEMBER_LABEL);
-      case Schedule.STUDIO:
-      case Schedule.TECH:
-        return colorPrefs.getColor(ColorPlan.STUDIO_LABEL);
-      case Schedule.ADMINISTRATIVE:
-        return colorPrefs.getColor(ColorPlan.ADMINISTRATIVE_LABEL);
-      default:
-        return colorPrefs.getColor(ColorPlan.LABEL);
-    }
-  }
-
-  /**
-   * Gets schedule range color.
-   *
-   * @param p schedule
-   * @param c basic color
-   * @return a color
-   */
-  protected Color getScheduleRangeColor(ScheduleObject p, Color c) {
-    if (p instanceof ScheduleRangeObject) {
-      Person a = ((ScheduleRangeObject) p).getMember();
-      if (a == null) {
-        c = Color.GRAY;
-      } else if (a.getId() == 0) {
-        c = c.darker();// break color
-      }
-    }
-    return c;
-  }
 
   /**
    * Gets the width of the colored range depending on number of students registered
@@ -404,4 +285,8 @@ public abstract class ScheduleCanvas
    * @param c display color
    */
   protected abstract void flagNotPaid(int col, int start, int end, Color c);
+
+  public ScheduleColorizer getColorizer() {
+    return colorizer;
+  }
 }

--- a/src/net/algem/planning/ScheduleColorizer.java
+++ b/src/net/algem/planning/ScheduleColorizer.java
@@ -1,0 +1,142 @@
+package net.algem.planning;
+
+import net.algem.config.ColorPlan;
+import net.algem.config.ColorPrefs;
+import net.algem.contact.Person;
+import net.algem.course.Course;
+import net.algem.room.Room;
+
+import java.awt.*;
+
+public class ScheduleColorizer {
+    private final ColorPrefs colorPrefs;
+    private final ActionIO actionIO;
+
+    public ScheduleColorizer(ColorPrefs colorPrefs, ActionIO actionIO) {
+        this.colorPrefs = colorPrefs;
+        this.actionIO = actionIO;
+    }
+
+    /**
+     * Gets the background color.
+     *
+     * @param p schedule
+     * @return a color
+     */
+    public Color getScheduleColor(ScheduleObject p) {
+        Color ac = null;
+        if (p instanceof ScheduleRangeObject) {
+            ac = getActionColor(((ScheduleRangeObject)p).getAction().getId());
+        } else {
+            ac = getActionColor(p.getIdAction());
+        }
+        if (ac != null) {
+            return (p instanceof ScheduleRangeObject ? ColorPrefs.brighten(ac) : ac);
+        }
+        return getDefaultScheduleColor(p);
+    }
+
+    public Color getDefaultScheduleColor(ScheduleObject p) {
+        if (p instanceof ScheduleRangeObject) {
+            return colorPrefs.getColor(ColorPlan.RANGE);
+        }
+        switch (p.getType()) {
+            case Schedule.COURSE:
+                Room s = ((CourseSchedule) p).getRoom();
+                Course cc = ((CourseSchedule) p).getCourse();
+                if (s.isCatchingUp()) {
+                    return colorPrefs.getColor(ColorPlan.CATCHING_UP);
+                } else {
+                    if (cc != null && !cc.isCollective()) {
+                        return colorPrefs.getColor(ColorPlan.COURSE_INDIVIDUAL);
+                    } else {
+                        if (cc != null && cc.isInstCode()) {
+                            return colorPrefs.getColor(ColorPlan.INSTRUMENT_CO);
+                        } else {
+                            return colorPrefs.getColor(ColorPlan.COURSE_CO);
+                        }
+                    }
+                }
+            case Schedule.ACTION:
+                return colorPrefs.getColor(ColorPlan.ACTION);
+            case Schedule.MEMBER:
+                return  colorPrefs.getColor(ColorPlan.MEMBER_REHEARSAL);
+            case Schedule.GROUP:
+                return  colorPrefs.getColor(ColorPlan.GROUP_REHEARSAL);
+            case Schedule.WORKSHOP:
+                return  colorPrefs.getColor(ColorPlan.WORKSHOP);
+            case Schedule.TRAINING:
+                return  colorPrefs.getColor(ColorPlan.TRAINING);
+            case Schedule.STUDIO:
+            case Schedule.TECH:
+                return  colorPrefs.getColor(ColorPlan.STUDIO);
+            case Schedule.ADMINISTRATIVE:
+                return colorPrefs.getColor(ColorPlan.ADMINISTRATIVE);
+            default:
+                return Color.WHITE;
+        } // end switch couleurs
+    }
+
+    private Color getActionColor(int action) {
+        return ((ActionIO) actionIO).getColor(action);
+    }
+
+    /**
+     * Gets the text color for headers.
+     *
+     * @param p schedule
+     * @return a color
+     */
+    public Color getTextColor(ScheduleObject p) {
+        Color ac = getActionColor(p.getIdAction());
+        if (ac != null) {
+            return ColorPrefs.getForeground(ac);
+        }
+        switch (p.getType()) {
+            case Schedule.COURSE:
+                CourseSchedule cs = (CourseSchedule) p;
+                Room r = p.getRoom();
+                if (r.isCatchingUp()) {
+                    return colorPrefs.getColor(ColorPlan.CATCHING_UP_LABEL);
+                } else if (cs.getCourse() != null && cs.getCourse().isCollective()) {
+                    return colorPrefs.getColor(ColorPlan.COURSE_CO_LABEL);
+                } else {
+                    return colorPrefs.getColor(ColorPlan.COURSE_INDIVIDUAL_LABEL);
+                }
+            case Schedule.WORKSHOP:
+                return colorPrefs.getColor(ColorPlan.WORKSHOP_LABEL);
+            case Schedule.TRAINING:
+                return colorPrefs.getColor(ColorPlan.TRAINING_LABEL);
+            case Schedule.GROUP:
+                return colorPrefs.getColor(ColorPlan.GROUP_LABEL);
+            case Schedule.MEMBER:
+                return colorPrefs.getColor(ColorPlan.MEMBER_LABEL);
+            case Schedule.STUDIO:
+            case Schedule.TECH:
+                return colorPrefs.getColor(ColorPlan.STUDIO_LABEL);
+            case Schedule.ADMINISTRATIVE:
+                return colorPrefs.getColor(ColorPlan.ADMINISTRATIVE_LABEL);
+            default:
+                return colorPrefs.getColor(ColorPlan.LABEL);
+        }
+    }
+
+    /**
+     * Gets schedule range color.
+     *
+     * @param p schedule
+     * @param c basic color
+     * @return a color
+     */
+    public Color getScheduleRangeColor(ScheduleObject p, Color c) {
+        if (p instanceof ScheduleRangeObject) {
+            Person a = ((ScheduleRangeObject) p).getMember();
+            if (a == null) {
+                c = Color.GRAY;
+            } else if (a.getId() == 0) {
+                c = c.darker();// break color
+            }
+        }
+        return c;
+    }
+}

--- a/src/net/algem/planning/day/DayPlanView.java
+++ b/src/net/algem/planning/day/DayPlanView.java
@@ -258,7 +258,7 @@ public class DayPlanView
   protected void drawSchedules(int i, Vector<ScheduleObject> v) {
     for (int j = 0; j < v.size(); j++) {
       ScheduleObject p = v.elementAt(j);
-      Color c = getScheduleColor(p);
+      Color c = colorizer.getScheduleColor(p);
       drawRange(i, p, c, step_x); // dessin des plannings p comme ScheduleObject
       if (p.getType() == Schedule.MEMBER || p.getType() == Schedule.GROUP) {
         if (p.getNote() == -1) {
@@ -288,7 +288,7 @@ public class DayPlanView
     // individual schedule ranges
     for (ScheduleRangeObject p : vp) {
       Course cc = p.getCourse();
-      c = getScheduleColor(p);
+      c = colorizer.getScheduleColor(p);
       if (cc != null && !cc.isCollective() || Schedule.ADMINISTRATIVE == p.getType()) {
         drawRange(i, p, c, step_x);
       }
@@ -309,14 +309,14 @@ public class DayPlanView
         continue;
       }
       w = getScheduleRangeWidth(vpci.get(idx).getAction().getPlaces(), n);
-      c = getScheduleColor(p);
+      c = colorizer.getScheduleColor(p);
       drawRange(i, vpci.get(idx), c, w);
       idp = p.getScheduleId();
       n = 1;
       idx = j;
     }
     // last schedule of the column
-    c = getScheduleColor(vpci.get(idx));
+    c = colorizer.getScheduleColor(vpci.get(idx));
     w = getScheduleRangeWidth(vpci.get(idx).getAction().getPlaces(), n);
     drawRange(i, vpci.get(idx), c, w);
   }
@@ -335,7 +335,7 @@ public class DayPlanView
     int y = setY(pStart);
     int ht = setY(pEnd) - y;
 
-    bg.setColor(getScheduleRangeColor(p, c));
+    bg.setColor(colorizer.getScheduleRangeColor(p, c));
     bg.fillRect(x, y, w - 1, ht - 1);
     bg.setColor(Color.black);
     // black line separator
@@ -371,7 +371,7 @@ public class DayPlanView
     int x = setX(col, 1);
     int y = setY(pStart);
 
-    bg.setColor(getTextColor(p));
+    bg.setColor(colorizer.getTextColor(p));
     bg.setFont(NORMAL_FONT);
 
     showLabel(p, prev, x, y);

--- a/src/net/algem/planning/day/DayScheduleCtrl.java
+++ b/src/net/algem/planning/day/DayScheduleCtrl.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Locale;
 import javax.swing.*;
 import net.algem.Algem;
+import net.algem.config.ColorPrefs;
 import net.algem.config.ConfigKey;
 import net.algem.config.ConfigUtil;
 import net.algem.planning.*;
@@ -210,7 +211,10 @@ public class DayScheduleCtrl
       File destFile = FileUtil.getSaveFile(view, "xls", BundleUtil.getLabel("Excel.file.label"), null);
       if (destFile != null) {
         try {
-          new PlanningExportService(new PlanningService(DataCache.getDataConnection())).exportPlanning(planning, destFile);
+          new PlanningExportService(
+                  new PlanningService(DataCache.getDataConnection()),
+                  new ScheduleColorizer(new ColorPrefs(), (ActionIO) DataCache.getDao(Model.Action))
+          ).exportPlanning(planning, destFile);
           new DesktopOpenHandler().open(destFile.getAbsolutePath());
         } catch (IOException e) {
           GemLogger.log(e.getMessage());

--- a/src/net/algem/planning/editing/PlanModifCtrl.java
+++ b/src/net/algem/planning/editing/PlanModifCtrl.java
@@ -426,7 +426,7 @@ public class PlanModifCtrl
     }
     try {
       Action a = ((CourseSchedule) plan).getAction();
-      ModifPlanActionDlg dlg = new ModifPlanActionDlg(desktop, a, new DayPlanView().getDefaultScheduleColor(plan));
+      ModifPlanActionDlg dlg = new ModifPlanActionDlg(desktop, a, new DayPlanView().getColorizer().getDefaultScheduleColor(plan));
       dlg.show();
       if (!dlg.isValidate()) {
         return;

--- a/src/net/algem/planning/export/PlanningExportService.java
+++ b/src/net/algem/planning/export/PlanningExportService.java
@@ -53,6 +53,9 @@ public class PlanningExportService
   private final ScheduleColorizer colorizer;
   private final PlanningService planningService;
 
+  private final static short COLOR_START_INDEX = 20;
+  private short colorIndex = COLOR_START_INDEX;
+
   public PlanningExportService(PlanningService service, ScheduleColorizer colorizer) {
     this.planningService = service;
     this.colorizer = colorizer;
@@ -73,6 +76,9 @@ public class PlanningExportService
     printSetup.setPaperSize(PrintSetup.A3_PAPERSIZE);
     sheet.setFitToPage(true);
     sheet.setHorizontallyCenter(true);
+
+    eraseAllColors(workbook);
+    colorIndex = COLOR_START_INDEX;
 
     Map<String, CellStyle> styles = createStyles(workbook);
 
@@ -130,6 +136,12 @@ public class PlanningExportService
     out.close();
   }
 
+  private void eraseAllColors(HSSFWorkbook workbook) {
+    for (short i = 0; i < 56; i++) {
+      workbook.getCustomPalette().setColorAtIndex(i, (byte) 0,(byte)  0, (byte) 0);
+    }
+  }
+
   private Map<String, CellStyle> createStyles(HSSFWorkbook wb) {
     Map<String, CellStyle> styles = new HashMap<>();
 
@@ -170,9 +182,9 @@ public class PlanningExportService
       style.setBorderBottom(CellStyle.BORDER_THIN);
       style.setFillPattern(CellStyle.SOLID_FOREGROUND);
       HSSFColor hffsColor = wb.getCustomPalette().findColor((byte) color.getRed(), (byte)color.getGreen(), (byte)color.getBlue());
-      short index = -1;
+      short index;
       if (hffsColor == null) {
-        index = wb.getCustomPalette().findSimilarColor((byte) color.getRed(), (byte)color.getGreen(), (byte)color.getBlue()).getIndex();
+        index = colorIndex++;
         wb.getCustomPalette().setColorAtIndex(index, (byte) color.getRed(), (byte)color.getGreen(), (byte)color.getBlue());
       } else {
         index = hffsColor.getIndex();

--- a/src/net/algem/planning/export/PlanningExportService.java
+++ b/src/net/algem/planning/export/PlanningExportService.java
@@ -20,12 +20,10 @@
  */
 package net.algem.planning.export;
 
-import net.algem.config.ColorPlan;
 import net.algem.config.ColorPrefs;
 import net.algem.course.Course;
 import net.algem.planning.*;
 import net.algem.planning.day.DayPlan;
-import net.algem.room.Room;
 import net.algem.util.GemLogger;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.*;
@@ -52,12 +50,12 @@ import org.apache.poi.hssf.util.HSSFColor;
 public class PlanningExportService
 {
 
-  private ColorPrefs colorPrefs;
-  private PlanningService planningService;
+  private final ScheduleColorizer colorizer;
+  private final PlanningService planningService;
 
-  public PlanningExportService(PlanningService service) {
+  public PlanningExportService(PlanningService service, ScheduleColorizer colorizer) {
     this.planningService = service;
-    colorPrefs = new ColorPrefs();
+    this.colorizer = colorizer;
   }
 
   public void exportPlanning(List<DayPlan> dayPlan, File destFile) throws IOException {
@@ -157,7 +155,7 @@ public class PlanningExportService
   }
 
   private CellStyle getCoursStyle(HSSFWorkbook wb, ScheduleObject o, Map<java.awt.Color, CellStyle> cache) {
-    java.awt.Color color = getScheduleColor(o);
+    java.awt.Color color = colorizer.getScheduleColor(o);
     CellStyle cachedStyle = cache.get(color);
     if (cachedStyle != null) {
       return cachedStyle;
@@ -211,48 +209,5 @@ public class PlanningExportService
         sb.append(p.getScheduleLabel());
     }
     return sb.toString();
-  }
-
-  protected java.awt.Color getScheduleColor(ScheduleObject p) {
-    java.awt.Color c = java.awt.Color.white;
-    switch (p.getType()) {
-      case Schedule.COURSE:
-        Room s = ((CourseSchedule) p).getRoom();
-        Course cc = ((CourseSchedule) p).getCourse();
-        if (s.isCatchingUp()) {
-          c = colorPrefs.getColor(ColorPlan.CATCHING_UP);
-        } else {
-          if (cc != null && !cc.isCollective()) {
-            c = colorPrefs.getColor(ColorPlan.COURSE_INDIVIDUAL);
-          } else {
-            if (cc != null && cc.isInstCode()) {
-              c = colorPrefs.getColor(ColorPlan.INSTRUMENT_CO);
-            } else {
-              c = colorPrefs.getColor(ColorPlan.COURSE_CO);
-            }
-          }
-        }
-        break;
-      case Schedule.ACTION:
-        c = colorPrefs.getColor(ColorPlan.ACTION);
-        break;
-      case Schedule.MEMBER:
-        c = colorPrefs.getColor(ColorPlan.MEMBER_REHEARSAL);
-        break;
-      case Schedule.GROUP:
-        c = colorPrefs.getColor(ColorPlan.GROUP_REHEARSAL);
-        break;
-      case Schedule.WORKSHOP:
-        c = colorPrefs.getColor(ColorPlan.WORKSHOP);
-        break;
-      case Schedule.TRAINING:
-        c = colorPrefs.getColor(ColorPlan.TRAINING);
-        break;
-      case Schedule.STUDIO:
-      case Schedule.TECH:
-        c = colorPrefs.getColor(ColorPlan.STUDIO);
-        break;
-    } // end switch couleurs
-    return c;
   }
 }

--- a/src/net/algem/planning/export/PlanningExportService.java
+++ b/src/net/algem/planning/export/PlanningExportService.java
@@ -53,7 +53,7 @@ public class PlanningExportService
   private final ScheduleColorizer colorizer;
   private final PlanningService planningService;
 
-  private final static short COLOR_START_INDEX = 20;
+  private final static short COLOR_START_INDEX = 24;
   private short colorIndex = COLOR_START_INDEX;
 
   public PlanningExportService(PlanningService service, ScheduleColorizer colorizer) {
@@ -137,7 +137,7 @@ public class PlanningExportService
   }
 
   private void eraseAllColors(HSSFWorkbook workbook) {
-    for (short i = 0; i < 56; i++) {
+    for (short i = COLOR_START_INDEX; i < 56; i++) {
       workbook.getCustomPalette().setColorAtIndex(i, (byte) 0,(byte)  0, (byte) 0);
     }
   }
@@ -181,14 +181,8 @@ public class PlanningExportService
       style.setBorderTop(CellStyle.BORDER_THIN);
       style.setBorderBottom(CellStyle.BORDER_THIN);
       style.setFillPattern(CellStyle.SOLID_FOREGROUND);
-      HSSFColor hffsColor = wb.getCustomPalette().findColor((byte) color.getRed(), (byte)color.getGreen(), (byte)color.getBlue());
-      short index;
-      if (hffsColor == null) {
-        index = colorIndex++;
-        wb.getCustomPalette().setColorAtIndex(index, (byte) color.getRed(), (byte)color.getGreen(), (byte)color.getBlue());
-      } else {
-        index = hffsColor.getIndex();
-      }
+      short index = colorIndex++;
+      wb.getCustomPalette().setColorAtIndex(index, (byte) color.getRed(), (byte)color.getGreen(), (byte)color.getBlue());
       style.setFillForegroundColor(index);
       cache.put(color, style);
       return style;

--- a/src/net/algem/planning/month/MonthPlanView.java
+++ b/src/net/algem/planning/month/MonthPlanView.java
@@ -183,7 +183,7 @@ public class MonthPlanView
   private void drawSchedules(Vector<ScheduleObject> plans) {
     for (int i = 0; i < plans.size(); i++) {
       ScheduleObject p = (ScheduleObject) plans.elementAt(i);
-      Color c = getScheduleColor(p);
+      Color c = colorizer.getScheduleColor(p);
       drawRange(p, c, step_x);
       if (p.getType() == Schedule.MEMBER || p.getType() == Schedule.GROUP) {
         if (p.getNote() == -1) {
@@ -288,7 +288,7 @@ public class MonthPlanView
       if (((Course) p.getActivity()).isCollective()) {
         int x = RIGHT_MARGIN + 0 + ((p.getDate().getDay() - 1) * step_x) - (step_x - 8);
         int y = setY(p.getStart().toMinutes());
-        bg.setColor(getTextColor(p));
+        bg.setColor(colorizer.getTextColor(p));
         bg.setFont(X_SMALL_FONT);
         showLabel(p, x, y);
       }


### PR DESCRIPTION
Bonjour Jean-Marc,

Je me suis rendu compte que le code de détermination des couleurs était redondé entre les vues et l'export XLS, j'avais fait ça pour faire simple à l'époque. Cela pose soucis car les codes ne sont plus en phase et cela provoque des incohérences entre la vue et l'export. J'ai donc factorisé cela dans un ScheduleColorizer.

**Note du commit**

Introduction de ScheduleColorizer dont la responsabilité déterminer la couleur d'un éléments de planning, permettant de mutualiser le code de détermination dans les vues et l'export (précédemment c'était redondé dans l'export et en retard sur les vues)
